### PR TITLE
Make the fetch tasks architecture agnostic

### DIFF
--- a/roles/build-percona-xtrabackup/tasks/main.yml
+++ b/roles/build-percona-xtrabackup/tasks/main.yml
@@ -70,5 +70,5 @@
 
 - name: Fetch percona-xtrabackup package file
   fetch:
-    src: "{{ percona_build_dir }}/percona-xtrabackup-{{ percona_xtrabackup_version_base }}_{{ percona_xtrabackup_version }}-1_ppc64el.deb"
+    src: "{{ percona_build_dir }}/percona-xtrabackup-{{ percona_xtrabackup_version_base }}_{{ percona_xtrabackup_version }}-1_{{ ansible_architecture }}.deb"
     dest: "{{ local_build_destination }}"

--- a/roles/build-qpress/tasks/main.yml
+++ b/roles/build-qpress/tasks/main.yml
@@ -66,5 +66,5 @@
 
 - name: Fetch qpress package file
   fetch:
-    src: "{{ qpress_build_dir }}/qpress_{{ qpress_version }}_ppc64el.deb"
+    src: "{{ qpress_build_dir }}/qpress_{{ qpress_version }}_{{ ansible_architecture }}.deb"
     dest: "{{ local_build_destination }}"


### PR DESCRIPTION
The roles to build `qpress` and `percona-xtrabackup` work on s390x
too. Only the fetch needed to be adapted to be not ppc64le specific.

Closes #1 